### PR TITLE
Resolve "marked as explicit... but not explicitly required" build errors

### DIFF
--- a/librclone-sys/build.rs
+++ b/librclone-sys/build.rs
@@ -17,6 +17,11 @@ fn main() {
     println!("cargo:rerun-if-changed=go.sum");
 
     Command::new("go")
+        .args(["mod", "vendor"])
+        .status()
+        .expect("`go mod vendor` failed. Is `go` installed and latest version?");
+
+    Command::new("go")
         .args(["build", "--buildmode=c-archive", "-o"])
         .arg(&format!("{}/librclone.a", out_dir))
         .arg("github.com/rclone/rclone/librclone")


### PR DESCRIPTION
I tried to add librclone to my project but encountered lots of errors like this when building (using Go version 1.22.2):
```
        github.com/gogo/protobuf@v1.3.2: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod
        github.com/golang-jwt/jwt/v4@v4.5.0: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod
        github.com/golang-jwt/jwt/v5@v5.0.0: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod
```
(and many many more)

I don't get these errors when I clone the repo directly and build it, seems to be specifically related to adding it as a dependency in another project.

I don't know much about Go, but googled it and found that running `go mod vendor` before building synchronises things. This has fixed the error for me.